### PR TITLE
Reorged the getting started tutorials

### DIFF
--- a/toc
+++ b/toc
@@ -5,15 +5,15 @@
 Watson Knowledge Studio
 
     {: .navgroup id="learn"}
-    index.md
-    system-requirements.md
-
     {: topicgroup}
     Getting started tutorials
         tutorials-create-project.md
         tutorials-create-ml-model.md
         tutorials-create-rule-model.md
         tutorials-bootstrap-annotation.md
+
+    index.md
+    system-requirements.md
     {: .navgroup-end}
 
     {: .navgroup id="reference"}


### PR DESCRIPTION
- The g-s section for WKS needed to be moved to the top of the LEARN section to be consistent with all the other Watson services and products

- Addresses https://github.ibm.com/watson/developer-experience/issues/3182