### PR TITLE
fixed a broken link to wks preannotation info

### DIFF
--- a/documents-for-annotation.md
+++ b/documents-for-annotation.md
@@ -139,7 +139,7 @@ To add documents to a project:
               CAS XMI format, you can
               import the <code>ZIP</code> file that contains the analyzed content. Specify that this is
               the type of content you want to import before you click <b>Import</b>. For details
-              about how to create these files and requirements for importing them, see [Importing pre-annotated documents ![External link icon](../../icons/launch-glyph.svg "External link icon")](wks_preannotate.html#wks_uima){: new_window}.</p>
+              about how to create these files and requirements for importing them, see [Importing pre-annotated documents ![External link icon](../../icons/launch-glyph.svg "External link icon")](preannotation.html#wks_uima){: new_window}.</p>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
This url leads to a broken link --> https://console.bluemix.net/docs/services/knowledge-studio/wks_preannotate.html#wks_uima

I switched it to this one --> https://console.bluemix.net/docs/services/knowledge-studio/preannotation.html#wks_uima

For this part of the page (the second url in the image below)

![screen shot 2018-01-03 at 12 50 54 pm](https://user-images.githubusercontent.com/18532719/34539296-c85d5116-f084-11e7-99f6-2c3123272f30.png)
